### PR TITLE
[codex] Add OWT AR H200 report and launcher

### DIFF
--- a/docs/experiments/agents/02-owt-ar-h200-bs512.md
+++ b/docs/experiments/agents/02-owt-ar-h200-bs512.md
@@ -1,0 +1,52 @@
+# 02-owt-ar-h200-bs512
+
+<details>
+<summary>Idea</summary>
+
+Train an autoregressive OpenWebText length-128 baseline on a single H200 for comparison against the 4-GPU FLM reference run. Preserve the reference global batch size where possible by using the largest tested single-GPU batch with no gradient accumulation.
+
+</details>
+
+<details>
+<summary>Changes</summary>
+
+- Added an H200 full-run launcher for AR OWT length-128 with `global_batch_size=512`, `batch_size=512`, and `eval_batch_size=128`.
+- Added AR/DiT runtime compatibility fixes needed on the H200 host: optional `flash_attn` fallback, AR `nll` signature alignment, and a TorchVision `VideoReader` shim.
+- Prepared OpenWebText train/validation length-128 wrapped caches under `/home/ubuntu/flm/cache`.
+
+</details>
+
+<details>
+<summary>Machine</summary>
+
+- **Host**: `computeinstance-e01b3fjb27x7tf8jyg`
+- **CPUs**: `16`
+- **GPUs**: `1 x NVIDIA H200`
+
+</details>
+
+<details>
+<summary>Reproduction</summary>
+
+```bash
+DATA_DIR=/home/ubuntu/flm/cache bash scripts/train_owt_ar.sh
+```
+
+</details>
+
+<details>
+<summary>Logs</summary>
+
+- **wandb**: [owt_full_ar_h200_bs512_eval128_25ecc6cd](https://wandb.ai/makartkar/flm/runs/25ecc6cd)
+- **checkpoints**: `/home/ubuntu/flm/runs/flm/owt_full_ar128_h200_20260612_120552/checkpoints`
+- **text logs**: `/home/ubuntu/flm/logs/run_full_ar128_h200_bs512_eval128.log`
+- **data cache**: `/home/ubuntu/flm/cache`
+
+</details>
+
+<details>
+<summary>Full chat</summary>
+
+`/Users/makartkar/.cursor/projects/Users-makartkar-work-bayes-group-flm-fork/agent-transcripts/c3dbf5c3-cbf8-481f-9ba4-51d4bc7fd605/c3dbf5c3-cbf8-481f-9ba4-51d4bc7fd605.jsonl`
+
+</details>

--- a/scripts/train_owt_ar.sh
+++ b/scripts/train_owt_ar.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+DATA_DIR="${DATA_DIR:-YOUR_DATA_DIR}"
+
+python -u -m main \
+  loader.global_batch_size=512 \
+  loader.batch_size=512 \
+  loader.eval_batch_size=128 \
+  data=openwebtext-split \
+  data.cache_dir=$DATA_DIR \
+  wandb.project=flm \
+  wandb.name=owt_full_ar \
+  model=small \
+  algo=ar \
+  model.length=128 \
+  sampling.num_sample_batches=1 \
+  sampling.steps=[1024] \
+  trainer.devices=1 \
+  trainer.max_steps=100000 \
+  trainer.precision=bf16 \
+  optim.lr=3e-4 \
+  trainer.val_check_interval=5000 \
+  callbacks.checkpoint_every_n_steps.every_n_train_steps=20000


### PR DESCRIPTION
## Summary
- add the AR OWT length-128 H200 experiment report as `02-owt-ar-h200-bs512`
- add a single repo-style `scripts/train_owt_ar.sh` launcher for the AR baseline
- keep the launcher generic with a `DATA_DIR` placeholder/env override and no host-specific run directory

## Validation
- rebased local `main` from `origin/main` before branching
- ran `bash -n scripts/train_owt_ar.sh`
